### PR TITLE
Issue #SB-6074 fix: Popup loading issue in question set

### DIFF
--- a/editor/style/style.css
+++ b/editor/style/style.css
@@ -1,0 +1,17 @@
+/*Questionset popup loading issue
+    while loading question set the full screen popup show
+*/
+.ui.modal.qb-question-bank {
+    top: 0 !important;
+    left: 0 !important;
+    height: 100vh;
+    width: 100% !important;
+    margin: 0 auto;
+    border-radius: 0;
+    display: flex;
+    -webkit-flex-flow: column;
+    -moz-flex-flow: column;
+    -ms-flex-flow: column;
+    -o-flex-flow: column;
+    flex-flow: column;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,9 @@
         "type": "plugin",
         "plugin": "org.ekstep.questionset.preview",
         "ver": "1.0"
+      },{
+        "type":"css",
+        "src":"editor/style/style.css"
       }
     ],
     "menu": [


### PR DESCRIPTION
PR related to
https://project-sunbird.atlassian.net/browse/SB-6074

Desc- Onclick questionset icon the question bank model popup load and all popup css load in question bank.so its take time to loading css.

fix-: Move popup css in question set plugin so when question set initialize then css will load.  